### PR TITLE
feat: provide version, git commit hash, and build time to the built hydra binary

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -48,7 +48,7 @@ parts:
 
       export CGO_ENABLED=0
       go mod download all
-      go install -ldflags="${go_linker_flags}" -p 1 ./...
+      go build -ldflags="${go_linker_flags}" -o "${CRAFT_PART_INSTALL}"/bin/hydra
     source: https://github.com/ory/hydra
     source-type: git
     source-tag: v2.1.1

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -34,9 +34,20 @@ parts:
     plugin: go
     build-snaps:
       - go/1.19/stable
-    build-environment:
-      - GOFLAGS: -ldflags=-w -ldflags=-s
-      - CGO_ENABLED: 0
+    override-build: |
+      src_config_path="github.com/ory/hydra/v2/driver"
+      build_ver="${src_config_path}/config.Version"
+      build_hash="${src_config_path}/config.Commit"
+      build_date="${src_config_path}/config.Date"
+      go_linker_flags="-w \
+                       -s \
+                       -X ${build_ver}=$(git -C "${CRAFT_PART_SRC}" describe --tags) \
+                       -X ${build_hash}=$(git -C "${CRAFT_PART_SRC}" rev-parse HEAD) \
+                       -X ${build_date}=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+      export CGO_ENABLED=0
+      go mod download all
+      go install -ldflags="${go_linker_flags}" -p 1 ./...
     source: https://github.com/ory/hydra
     source-type: git
     source-tag: v2.1.1


### PR DESCRIPTION
### Context

The built `hydra` binary in the ROCK image needs to align versioning with the upstream. Currently, the binary lacks the version, the corresponding commit hash, and the build time. We would like to add such information to the built binary so that users of the `hydra` operator could expect the same experience as they would when using the upstream binary.

### Testing Locally

- Build the ROCK image with `rockcraft pack -v`
- Follow the instruction [HERE](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/tutorials/hello-world.html#run-the-rock-in-docker) to run with Docker with `docker run --rm --name hydra <image name>:<image tag> exec hydra version`