### PR TITLE
Remove certs from rock

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -31,11 +31,6 @@ parts:
       # This is needed to pipe the stdout/stderr to a file for log forwarding
       - dash
 
-  certificates:
-    plugin: nil
-    stage-packages:
-      - ca-certificates
-
   hydra:
     plugin: go
     build-snaps:


### PR DESCRIPTION
Hydra does not make any HTTPS calls, no need to install the certificate package in the image.

This change reduces the image size from 77MB to 70MB